### PR TITLE
Adding Service Bus Worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 .glide/
 
 vendor/
+
+.env

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,15 +8,42 @@
   revision = "40e40b42552a9cb37d6e98f4ad31f63ae53ea43a"
 
 [[projects]]
+  name = "github.com/Azure/azure-amqp-common-go"
+  packages = [
+    ".",
+    "auth",
+    "cbs",
+    "conn",
+    "internal",
+    "internal/tracing",
+    "log",
+    "rpc",
+    "sas",
+    "uuid"
+  ]
+  revision = "e05d7e9b03e1fd3a074d0f0b819bad445e3a0a69"
+  version = "v0.6.0"
+
+[[projects]]
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
     "profiles/latest/resources/mgmt/subscriptions",
     "services/resources/mgmt/2016-06-01/subscriptions",
     "services/resources/mgmt/2017-05-10/resources",
+    "services/servicebus/mgmt/2017-04-01/servicebus",
     "version"
   ]
-  revision = "fbe7db0e3f9793ba3e5704efbab84f51436c136e"
-  version = "v18.0.0"
+  revision = "34e80a61f817f18afd85d0c6d12ee6400d6506b2"
+  version = "v18.1.0"
+
+[[projects]]
+  name = "github.com/Azure/azure-service-bus-go"
+  packages = [
+    ".",
+    "atom"
+  ]
+  revision = "88613d3356e8ce24659eb44cc5bd6a34e250703a"
+  version = "v0.1.0"
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
@@ -28,8 +55,8 @@
     "autorest/to",
     "autorest/validation"
   ]
-  revision = "1f7cd6cfe0adea687ad44a512dfe76140f804318"
-  version = "v10.12.0"
+  revision = "894522ed0d5cab8d143c39116ddc5f605a1931ee"
+  version = "v10.13.0"
 
 [[projects]]
   branch = "master"
@@ -47,7 +74,7 @@
   branch = "master"
   name = "github.com/dustin/go-humanize"
   packages = ["."]
-  revision = "02af3965c54e8cacf948b97fef38925c4120652c"
+  revision = "9f541cc9db5d55bce703bd99987c9d5cb8eea45e"
 
 [[projects]]
   name = "github.com/fatih/color"
@@ -99,8 +126,8 @@
     ".",
     "translators"
   ]
-  revision = "25461ee937655cd1136523f6653d5bd15343cc48"
-  version = "v1.0.1"
+  revision = "a68affc47dc7145d791149e996c379a0f46ee507"
+  version = "v1.0.2"
 
 [[projects]]
   name = "github.com/gobuffalo/makr"
@@ -320,10 +347,10 @@
   version = "v1.9.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/microcosm-cc/bluemonday"
   packages = ["."]
-  revision = "f0761eb8ed07c1cc892ef631b00c33463b9b6868"
+  revision = "dafebb5b6ff2861a0d69af64991e10866c19be85"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -335,13 +362,23 @@
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "bb74f1db0675b241733089d5a1faa5dd8b0ef57b"
+  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
   name = "github.com/monoculum/formam"
   packages = ["."]
   revision = "99ca9dcbaca6d91e9665f817d0da23af6184ced3"
   version = "v3.0"
+
+[[projects]]
+  name = "github.com/opentracing/opentracing-go"
+  packages = [
+    ".",
+    "ext",
+    "log"
+  ]
+  revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
+  version = "v1.0.2"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
@@ -360,6 +397,12 @@
   name = "github.com/russross/blackfriday"
   packages = ["."]
   revision = "11635eb403ff09dbc3a6b5a007ab5ab09151c229"
+
+[[projects]]
+  name = "github.com/satori/uuid"
+  packages = ["."]
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -491,7 +534,7 @@
     "blowfish",
     "ssh/terminal"
   ]
-  revision = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
+  revision = "a2144134853fc9a27a7b1e3eb4f19f1a76df13c9"
 
 [[projects]]
   branch = "master"
@@ -501,7 +544,7 @@
     "html",
     "html/atom"
   ]
-  revision = "039a4258aec0ad3c79b905677cceeab13b296a77"
+  revision = "81d44fd177a98d09fe3bc40a5a78d495d3f042ea"
 
 [[projects]]
   branch = "master"
@@ -516,7 +559,7 @@
     "unix",
     "windows"
   ]
-  revision = "1b2967e3c290b7c545b3db0deeda16e9be4f98a2"
+  revision = "ac767d655b305d4e9612f5f6e33120b9176c4ad4"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -543,9 +586,18 @@
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
+[[projects]]
+  name = "pack.ag/amqp"
+  packages = [
+    ".",
+    "internal/testconn"
+  ]
+  revision = "751cf0d4eb77d69534dabeff0f3afb2a0eb8588c"
+  version = "v0.6.2"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c517cccb1716027c9f086f3030e185782fab475b57f279e72b3a7d00b24848b6"
+  inputs-digest = "d173ce6ac25f44ee7cba773182657e70959297150bf87b8a98ca039924473ef0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -49,7 +49,7 @@
   name = "github.com/joho/godotenv"
   version = "^1.2.0"
 
-[[constraint]]
+[[override]]
   name = "github.com/Azure/azure-sdk-for-go"
   version = "^18.0.0"
 
@@ -60,3 +60,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/Azure/azure-service-bus-go"
+  version = "0.1.0"

--- a/worker/common.go
+++ b/worker/common.go
@@ -1,0 +1,24 @@
+package worker
+
+import (
+	"context"
+	"time"
+
+	bufwork "github.com/gobuffalo/buffalo/worker"
+)
+
+// Receiver encapsulates the methods that must be implemented to do processing created by a
+// publish to a Worker's queue.
+type Receiver interface {
+	Start(context.Context) error
+	Stop() error
+	Register(string, bufwork.Handler) error
+}
+
+// Publisher declares all of the functionality a type must have to be able to enqueue Jobs for
+// a Buffalo worker to start processing.
+type Publisher interface {
+	Perform(bufwork.Job) error
+	PerformAt(bufwork.Job, time.Time) error
+	PerformIn(bufwork.Job, time.Duration) error
+}

--- a/worker/doc.go
+++ b/worker/doc.go
@@ -1,0 +1,2 @@
+// Package worker hosts the implementation(s) of the `github.com/gobuffalo/buffalo.Worker` interface.
+package worker

--- a/worker/servicebus.go
+++ b/worker/servicebus.go
@@ -1,0 +1,197 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	servicebus "github.com/Azure/azure-service-bus-go"
+	bufwork "github.com/gobuffalo/buffalo/worker"
+)
+
+type queuePool map[string]*servicebus.Queue
+
+type (
+	// ServiceBusReceiver is able to listen to a ServiceBus Queue and do Buffalo Jobs.
+	ServiceBusReceiver struct {
+		pool     queuePool
+		handlers map[string]bufwork.Handler
+		handles  map[string]*servicebus.ListenerHandle
+		ctx      context.Context
+		mut      sync.RWMutex
+	}
+
+	// ServiceBusPublisher is able to write Buffalo Jobs to ServiceBus Queue.
+	ServiceBusPublisher struct {
+		pool queuePool
+	}
+
+	// ServiceBus is a compound type, which fulfills the entire interface defined by the type
+	// `github.com/gobuffalo/buffalo/worker.Worker`.
+	//
+	// The same connection pool is used for both the ServiceBusPublisher and ServiceBusRececiver.
+	ServiceBus struct {
+		ServiceBusPublisher
+		ServiceBusReceiver
+	}
+)
+
+// NewServiceBusReceiver is a constructor for the type `ServiceBusReceiver`.
+func NewServiceBusReceiver(queues ...*servicebus.Queue) *ServiceBusReceiver {
+	return &ServiceBusReceiver{
+		pool:     newQueuePool(queues),
+		handlers: make(map[string]bufwork.Handler),
+		handles:  make(map[string]*servicebus.ListenerHandle, len(queues)),
+	}
+}
+
+// Register binds a function that should be called when a Job calling for a particular value of Handler is
+// received.
+func (sbr *ServiceBusReceiver) Register(name string, processor bufwork.Handler) error {
+	sbr.mut.Lock()
+	defer sbr.mut.Unlock()
+
+	sbr.handlers[name] = processor
+	return nil
+}
+
+// Start begins listening to a ServiceBus Queue in order to handle github.com/gobuffalo/buffalo/worker.Jobs
+// that come accross the wire as Service Bus Messages.
+//
+// Start returns immediately without blocking. To have this worker Stop, see the Stop() message.
+func (sbr *ServiceBusReceiver) Start(ctx context.Context) (err error) {
+	sbr.mut.RLock()
+	defer sbr.mut.RUnlock()
+
+	sbr.ctx = ctx
+	for name, client := range sbr.pool {
+		var handle *servicebus.ListenerHandle
+		handle, err = client.Receive(ctx, sbr.dispatch)
+		if err != nil {
+			break
+		}
+		sbr.handles[name] = handle
+	}
+
+	// Having `Start` partially complete could cause connection leaks, or have it be hard to reason about
+	// the existing state. For that reason, if even one Queue listener fails to start listening, the clause
+	// below will stop any of the queues that had successfully started listening.
+	if err != nil {
+		sbr.stop()
+	}
+
+	return
+}
+
+// Stop makes this instance of a ServiceBus listener cease listening for Jobs.
+func (sbr *ServiceBusReceiver) Stop() error {
+	sbr.mut.Lock()
+	defer sbr.mut.Unlock()
+
+	return sbr.stop()
+}
+
+// stop closes all open queue Receive operations, and resets the context from when it was started. It
+// takes no lock, and therefor is only suitable for internal consumption.
+func (sbr *ServiceBusReceiver) stop() error {
+	for _, handle := range sbr.handles {
+		handle.Close(sbr.ctx)
+	}
+	sbr.ctx = nil
+	return nil
+}
+
+func (sbr *ServiceBusReceiver) dispatch(ctx context.Context, message *servicebus.Message) servicebus.DispositionAction {
+	var j bufwork.Job
+	err := json.Unmarshal(message.Data, &j)
+	if err != nil {
+		// Poorly formatted message, throw it away.
+		return message.DeadLetter(err)
+	}
+
+	// Once we've started doing the job, we should complete it and communicate with ServiceBus. For that reason, we can
+	// take out a very focused lock, instead of blocking changes to the ServiceBusReceiver.
+	sbr.mut.RLock()
+	handler, ok := sbr.handlers[j.Handler]
+	sbr.mut.RUnlock()
+
+	if ok {
+		handler(j.Args)
+	} else {
+		// A message that can't be handled by this ServiceBusReceiver, try it again somewhere else.
+		return message.Abandon()
+	}
+
+	return message.Complete()
+}
+
+// NewServiceBusPublisher is a constructor for the type `ServiceBusPublisher`.
+func NewServiceBusPublisher(queues ...*servicebus.Queue) *ServiceBusPublisher {
+	return &ServiceBusPublisher{
+		pool: newQueuePool(queues),
+	}
+}
+
+// Perform schedules a `Job` to be run as soon as possible.
+func (sbp *ServiceBusPublisher) Perform(job bufwork.Job) (err error) {
+	return sbp.publish(job, nil)
+}
+
+// PerformAt schedules a `Job` to be performed at a particular time.
+func (sbp *ServiceBusPublisher) PerformAt(job bufwork.Job, at time.Time) error {
+	return sbp.publish(job, &servicebus.SystemProperties{
+		ScheduledEnqueueTime: &at,
+	})
+}
+
+// PerformIn schedules a `Job` to be performed after waiting for a set amount of time.
+func (sbp *ServiceBusPublisher) PerformIn(job bufwork.Job, in time.Duration) error {
+	return sbp.PerformAt(job, time.Now().Add(in))
+}
+
+func (sbp *ServiceBusPublisher) publish(job bufwork.Job, messageProperties *servicebus.SystemProperties) error {
+	client, ok := sbp.pool[job.Queue]
+	if !ok {
+		return fmt.Errorf("unknown queue %q", job.Queue)
+	}
+
+	marshaled, err := json.Marshal(job)
+	if err != nil {
+		return err
+	}
+
+	message := servicebus.NewMessage(marshaled)
+	message.SystemProperties = messageProperties
+
+	return client.Send(context.Background(), message)
+}
+
+// NewServiceBus is a constructor for the compound type ServiceBus. It instantiates a ServiceBusPublisher and ServiceBusReceiver
+// that share connection resources.
+func NewServiceBus(queues ...*servicebus.Queue) (retval *ServiceBus, _ error) {
+	pool := newQueuePool(queues)
+
+	retval = new(ServiceBus)
+
+	retval.ServiceBusPublisher = ServiceBusPublisher{
+		pool: pool,
+	}
+
+	retval.ServiceBusReceiver = ServiceBusReceiver{
+		pool:     pool,
+		handlers: make(map[string]bufwork.Handler),
+		handles:  make(map[string]*servicebus.ListenerHandle, len(queues)),
+	}
+	return
+}
+
+func newQueuePool(queues []*servicebus.Queue) (retval queuePool) {
+	retval = make(queuePool, len(queues))
+
+	for i := range queues {
+		retval[queues[i].Name] = queues[i]
+	}
+	return
+}

--- a/worker/servicebus_examples_test.go
+++ b/worker/servicebus_examples_test.go
@@ -1,0 +1,50 @@
+package worker_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	servicebus "github.com/Azure/azure-service-bus-go"
+	azwork "github.com/Azure/buffalo-azure/worker"
+	"github.com/gobuffalo/buffalo/worker"
+)
+
+func ExampleServiceBusPublisher_initializeAndSend() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Create a client that can communicate with a particular Service Bus Namespace.
+	sbConnection := "<your service bus connection string>"
+	nsOpts := []servicebus.NamespaceOption{
+		servicebus.NamespaceWithConnectionString(sbConnection),
+	}
+
+	ns, err := servicebus.NewNamespace(nsOpts...)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "unable to create namespace client: ", err)
+		return
+	}
+
+	// Create a client that can communicate with a particular Service Bus Queue.
+	queueName := "<your queue name>"
+	queue, err := ns.NewQueue(ctx, queueName)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "unable to create queue client", err)
+		return
+	}
+
+	// Create the client which knows how to publish jobs that will be carried out
+	// by a ServiceBusReceiver which knows how to actually do the job.
+	myPublisher := azwork.NewServiceBusPublisher(queue)
+
+	// Start sending jobs to be processed somewhere else!
+	myPublisher.Perform(worker.Job{
+		Queue: queueName,
+		Args: worker.Args{
+			"source": "https://notarealdomain.com/gomodules/buffalo-azure/worker.zip",
+		},
+		Handler: "downloader",
+	})
+}

--- a/worker/servicebus_examples_test.go
+++ b/worker/servicebus_examples_test.go
@@ -1,43 +1,26 @@
 package worker_test
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"time"
 
-	servicebus "github.com/Azure/azure-service-bus-go"
 	azwork "github.com/Azure/buffalo-azure/worker"
 	"github.com/gobuffalo/buffalo/worker"
 )
 
 func ExampleServiceBusPublisher_initializeAndSend() {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	// Create a client that can communicate with a particular Service Bus Namespace.
 	sbConnection := "<your service bus connection string>"
-	nsOpts := []servicebus.NamespaceOption{
-		servicebus.NamespaceWithConnectionString(sbConnection),
-	}
-
-	ns, err := servicebus.NewNamespace(nsOpts...)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "unable to create namespace client: ", err)
-		return
-	}
+	queueName := "<your queue name>"
 
 	// Create a client that can communicate with a particular Service Bus Queue.
-	queueName := "<your queue name>"
-	queue, err := ns.NewQueue(ctx, queueName)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "unable to create queue client", err)
-		return
-	}
 
 	// Create the client which knows how to publish jobs that will be carried out
 	// by a ServiceBusReceiver which knows how to actually do the job.
-	myPublisher := azwork.NewServiceBusPublisher(queue)
+	myPublisher, err := azwork.NewServiceBusPublisher(sbConnection, 1)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
 
 	// Start sending jobs to be processed somewhere else!
 	myPublisher.Perform(worker.Job{

--- a/worker/servicebus_test.go
+++ b/worker/servicebus_test.go
@@ -32,6 +32,10 @@ func TestServiceBus_StartStop_noQueues(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	if skipIfMissingConfig(t, ServiceBusConnection) {
+		return
+	}
+
 	subject, err := NewServiceBus(config.GetString(ServiceBusConnection), 0)
 	if err != nil {
 		t.Error(err)

--- a/worker/servicebus_test.go
+++ b/worker/servicebus_test.go
@@ -1,0 +1,151 @@
+// +build !offline
+
+package worker
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	servicebus "github.com/Azure/azure-service-bus-go"
+	"github.com/gobuffalo/buffalo/worker"
+	"github.com/joho/godotenv"
+	"github.com/satori/uuid"
+	"github.com/spf13/viper"
+)
+
+var config = viper.New()
+
+// All viper names of inputs into this test harness to light-up different tests.
+const (
+	ServiceBusConnection                    = "sb-conn"
+	ServiceBusConnectionEnvironmentVariable = "BUFFALO_AZURE_TEST_SERVICE_BUS_CONNECTION"
+)
+
+func init() {
+	godotenv.Overload("./.env", "../.env")
+
+	config.BindEnv(ServiceBusConnection, ServiceBusConnectionEnvironmentVariable)
+}
+
+func TestServiceBus_StartStop_noQueues(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	subject, err := NewServiceBus()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = subject.Start(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = subject.Stop()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}
+
+func TestServiceBus_SendReceive(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const handlerIdent = "test-receiver"
+
+	if skipIfMissingConfig(t, ServiceBusConnection) {
+		return
+	}
+
+	ns, err := servicebus.NewNamespace(servicebus.NamespaceWithConnectionString(config.GetString(ServiceBusConnection)))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	queueName := uuid.NewV1().String()
+	mgmtClient := ns.NewQueueManager()
+
+	if _, err := mgmtClient.Put(ctx, queueName); err != nil {
+		t.Error(err)
+		return
+	}
+	defer mgmtClient.Delete(context.Background(), queueName)
+
+	queue, err := ns.NewQueue(ctx, queueName)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	subject, err := NewServiceBus(queue)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	conduit := make(chan string)
+
+	var handler worker.Handler = func(args worker.Args) error {
+		left := args["left"].(string)
+		right := args["right"].(string)
+
+		conduit <- fmt.Sprintf("%s %s", left, right)
+		return nil
+	}
+
+	subject.Register(handlerIdent, handler)
+
+	err = subject.Start(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer subject.Stop()
+
+	// Using prime numbers so there is no other combination that could work.
+	const left, right = "Hello", "World!"
+	const want = left + " " + right
+
+	expected := worker.Job{
+		Queue:   queueName,
+		Handler: handlerIdent,
+		Args: worker.Args{
+			"left":  left,
+			"right": right,
+		},
+	}
+
+	err = subject.Perform(expected)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	select {
+	case <-ctx.Done():
+		t.Log("timed out")
+		t.Fail()
+	case got := <-conduit:
+		if got != want {
+			t.Logf("got: %s want: %s", got, want)
+			t.Fail()
+		}
+	}
+}
+
+func skipIfMissingConfig(t *testing.T, params ...string) bool {
+	missingRequired := false
+	for i := range params {
+		if !config.IsSet(params[i]) {
+			t.Skipf("Unable to find required parameter %q", params[i])
+			missingRequired = true
+		}
+	}
+	return missingRequired
+}


### PR DESCRIPTION
Adding an implementation of [`github.com/gobuffalo/buffalo/worker.Worker`](https://godoc.org/github.com/gobuffalo/buffalo/worker#Worker) that uses Azure Service Bus to persist Jobs, distribute them between available machines, and provide Job status monitoring.

Reviewers, some open questions I still have:
- Is `github.com/Azure/buffalo-azure/worker` a good package name for this? Would `github.com/Azure/buffalo-azure/sdk/worker` be better? I'm leaning towards the latter.
- Is tying together the notion of `Queue` as its defined in [`worker.Job`](https://godoc.org/github.com/gobuffalo/buffalo/worker#Job) and a Service Bus Queue, as I've done here, appropriate?
- For `ServiceBusPublisher`, should I add a "DefaultQueue" that will override which overrides the empty string if that's what's present in a Job?
- How is the documentation I've added here? Any other examples I should add?
- Is it clear why I broke up my implementation of the `Worker` interface into two halves? 

@arschles @markbates 